### PR TITLE
docs: add and fix missing docstrings

### DIFF
--- a/custom_components/pi_hole_v6/__init__.py
+++ b/custom_components/pi_hole_v6/__init__.py
@@ -51,7 +51,15 @@ class PiHoleV6Data:
 
 
 async def check_result(result: dict[str, Any], api_client: PiholeAPI) -> None:
-    """..."""
+    """Check that the API result is a valid dictionary.
+
+    If the result is not a dict, logs an error, calls logout and raises DataStructureError.
+
+    Args:
+        result (dict[str, Any]): The result returned by the API call.
+        api_client (PiholeAPI): The Pi-hole API client instance used to call logout.
+
+    """
 
     if not isinstance(result, dict):
         await api_client.call_logout()
@@ -60,7 +68,14 @@ async def check_result(result: dict[str, Any], api_client: PiholeAPI) -> None:
 
 
 async def async_get_all_data(api_client: PiholeAPI) -> None:
-    """..."""
+    """Fetch all required data from the Pi-hole API.
+
+    Sequentially calls each API endpoint and validates the result structure.
+
+    Args:
+        api_client (PiholeAPI): The Pi-hole API client instance used to perform the calls.
+
+    """
 
     result = await api_client.call_summary()
     await check_result(result, api_client)

--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -157,7 +157,18 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def _try_to_retrieve_json_result(self, request: requests.Response, privacy: bool = True) -> str | None:
-        """..."""
+        """Attempt to parse the JSON body from an HTTP response.
+
+        Handles encoding errors gracefully and optionally redacts the session SID for privacy.
+
+        Args:
+            request (requests.Response): The HTTP response object to parse.
+            privacy (bool): If True, redacts the session SID from the result. Defaults to True.
+
+        Returns:
+            str | None: The parsed JSON content, or None if the response has no body.
+
+        """
 
         text: str | None = None
 
@@ -183,7 +194,17 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         return text
 
     async def _create_log_message_on_api_result(self, request: requests.Response, method: str, url: str) -> str:
-        """..."""
+        """Build a log message string from an HTTP response.
+
+        Args:
+            request (requests.Response): The HTTP response object.
+            method (str): The HTTP method used for the request.
+            url (str): The URL of the request.
+
+        Returns:
+            str: A formatted log message containing status, reason, method, URL and response body.
+
+        """
 
         text: str | None = await self._try_to_retrieve_json_result(request)
         status: str = str(request.status)
@@ -194,7 +215,18 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
     async def _create_log_message_on_api_exception(
         self, api_error: APIError, request: requests.Response, method: str, url: str
     ) -> str:
-        """..."""
+        """Build a log message string from an API exception and its associated HTTP response.
+
+        Args:
+            api_error (APIError): The API exception that was raised.
+            request (requests.Response): The HTTP response object associated with the error.
+            method (str): The HTTP method used for the request.
+            url (str): The URL of the request.
+
+        Returns:
+            str: A formatted log message prefixed with the exception type name.
+
+        """
 
         log: str = await self._create_log_message_on_api_result(request, method, url)
         exception_name: str = str(type(api_error))
@@ -202,13 +234,29 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         return f"{exception_name} - {log}"
 
     async def _authentification_step(self, action: str) -> None:
-        """..."""
+        """Execute the full authentication sequence for a given action.
+
+        Checks current authentication status, aborts logout if not needed,
+        and requests a login if no session is active.
+
+        Args:
+            action (str): The name of the action being performed, used to determine authentication behavior.
+
+        """
         await self._check_authentification(action)
         await self._abort_logout(action)
         await self._request_login(action)
 
     async def _authentification_step_with_lock(self, action: str) -> None:
-        """..."""
+        """Execute the authentication sequence with a lock for non-auth actions.
+
+        Acquires the call lock before running the authentication step to prevent
+        concurrent authentication attempts. Auth-related actions bypass the lock.
+
+        Args:
+            action (str): The name of the action being performed.
+
+        """
 
         if action not in ("login", "authentification_status", "logout"):
             try:
@@ -226,7 +274,15 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
             await self._authentification_step(action)
 
     async def _check_authentification(self, action: str) -> None:
-        """..."""
+        """Verify the current session is still valid and reset it if not.
+
+        Calls the authentication status endpoint and sets the SID to None
+        if the session has expired or become invalid.
+
+        Args:
+            action (str): The name of the action being performed, used to skip the check for auth-related actions.
+
+        """
 
         try:
             if (
@@ -243,19 +299,40 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
             self._sid = None
 
     async def _request_login(self, action: str) -> None:
-        """..."""
+        """Request a login if no active session exists.
+
+        Triggers a login call when the action is not already a login
+        and no session ID is currently set.
+
+        Args:
+            action (str): The name of the action being performed.
+
+        """
 
         if action != "login" and self._sid is None:
             await self.call_login()
 
     async def _abort_logout(self, action: str) -> None:
-        """..."""
+        """Abort a logout call if no active session exists.
+
+        Raises AbortLogoutError when a logout is requested but there is
+        no active session to terminate.
+
+        Args:
+            action (str): The name of the action being performed.
+
+        """
 
         if action == "logout" and (self._sid is None or self._sid == "no password set"):
             raise AbortLogoutError
 
     async def call_authentification_status(self) -> dict[str, Any]:
-        """..."""
+        """Retrieve the current authentication session status.
+
+        Returns:
+            dict[str, Any]: A dictionary with the keys "code", "reason", and "data".
+
+        """
 
         url: str = "/auth"
 
@@ -774,7 +851,12 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     def remove_cache(self, data_name: str) -> None:
-        """..."""
+        """Reset a specific cache entry to its default error state.
+
+        Args:
+            data_name (str): The name of the cache to reset. Currently supports "ftl_info_messages".
+
+        """
 
         match data_name:
             case "ftl_info_messages":

--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -52,7 +52,9 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         """Initialize Pi-hole API Client object with an API URL and an optional logger.
 
         Args:
+          session (client.ClientSession): The aiohttp client session used to perform HTTP requests.
           url (str): Represents the URL of API endpoint. Defaults to "http://pi.hole".
+          password (str): The password used to authenticate against the Pi-hole API. Defaults to "".
           logger (Logger | None): Expects an object of type `Logger` or `None` which will be used to display debug message.
 
         """
@@ -349,10 +351,7 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def call_login(self) -> dict[str, Any]:
-        """Authenticate a user with a password.
-
-        Args:
-          password (str): Represents tne password used to authenticate the user during the login process.
+        """Authenticate against the Pi-hole API using the configured password.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -439,6 +438,9 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
 
     async def call_padd(self, full: bool = True) -> dict[str, Any]:
         """Retrieve the Pi-hole API Dashboard information.
+
+        Args:
+          full (bool): If True, retrieves the full dashboard data. Defaults to True.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -538,7 +540,7 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         """Disable blocking for DNS requests.
 
         Args:
-          duration (int | None): Represents the time duration in seconds for which the blocking feature will be disabled. Defaults to 120
+          duration (int | None): The time duration in seconds for which blocking will be disabled. Pass None to disable indefinitely.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -568,7 +570,7 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def call_get_ftl_info_messages(self) -> dict[str, Any]:
-        """Get FTL information messages.
+        """Retrieve the list of FTL diagnosis messages.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -593,7 +595,7 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def call_get_ftl_info_messages_count(self) -> dict[str, Any]:
-        """Get FTL information messages.
+        """Retrieve the count of FTL diagnosis messages.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -697,7 +699,10 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def call_group_disable(self, group: str) -> dict[str, Any]:
-        """Disable Pi-hole group.
+        """Disable a Pi-hole group.
+
+        Args:
+          group (str): The name of the group to disable.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -724,7 +729,10 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         }
 
     async def call_group_enable(self, group: str) -> dict[str, Any]:
-        """Enable Pi-hole group.
+        """Enable a Pi-hole group.
+
+        Args:
+          group (str): The name of the group to enable.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".
@@ -797,7 +805,7 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
         return await self._call_action("restartdns")
 
     async def call_action_ftl_purge_diagnosis_messages(self) -> dict[str, Any]:
-        """Purge FTP diagnosis messages.
+        """Purge all FTL diagnosis messages.
 
         Returns:
           result (dict[str, Any]): A dictionary with the keys "code", "reason", and "data".

--- a/custom_components/pi_hole_v6/button.py
+++ b/custom_components/pi_hole_v6/button.py
@@ -63,7 +63,7 @@ async def async_setup_entry(
     entry: PiHoleV6ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """..."""
+    """Set up the Pi-hole V6 button entities."""
 
     hole_data = entry.runtime_data
 

--- a/custom_components/pi_hole_v6/common.py
+++ b/custom_components/pi_hole_v6/common.py
@@ -1,4 +1,4 @@
-"""..."""
+"""Common helper functions for Pi-hole V6 integration."""
 
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -9,7 +9,17 @@ from homeassistant.core import HomeAssistant
 
 
 def find_entity_switch(current_hass: HomeAssistant, key: str, context_name: str) -> Any:
-    """..."""
+    """Find a switch entity by its key within a given context.
+
+    Args:
+        current_hass (HomeAssistant): The Home Assistant instance.
+        key (str): The entity description key or group-based composite key to match.
+        context_name (str): The name of the Pi-hole instance used to scope the entity list.
+
+    Returns:
+        Any: The matching switch entity, or None if not found.
+
+    """
 
     for entity in current_hass.data.get(f"pi_hole_entities_switch_{context_name}", []):
         if hasattr(entity, "entity_description"):
@@ -23,7 +33,17 @@ def find_entity_switch(current_hass: HomeAssistant, key: str, context_name: str)
 
 
 def find_entity_sensor(current_hass: HomeAssistant, key: str, context_name: str) -> Any:
-    """..."""
+    """Find a sensor entity by its key within a given context.
+
+    Args:
+        current_hass (HomeAssistant): The Home Assistant instance.
+        key (str): The entity description key to match.
+        context_name (str): The name of the Pi-hole instance used to scope the entity list.
+
+    Returns:
+        Any: The matching sensor entity, or None if not found.
+
+    """
 
     for entity in current_hass.data.get(f"pi_hole_entities_sensor_{context_name}", []):
         if hasattr(entity, "entity_description") and entity.entity_description.key == key:
@@ -33,7 +53,16 @@ def find_entity_sensor(current_hass: HomeAssistant, key: str, context_name: str)
 
 
 def calculate_remaining_until_blocking_mode_until_value(entity: Any, remaining_key: str) -> int:
-    """..."""
+    """Calculate the remaining seconds until the blocking mode is automatically restored.
+
+    Args:
+        entity (Any): The entity holding the API cache with remaining dates.
+        remaining_key (str): The key used to look up the target datetime in the cache.
+
+    Returns:
+        int: The remaining seconds as a positive integer, 0 if the date has passed, or -1 if the key is not present.
+
+    """
 
     new_value = -1
 
@@ -47,7 +76,16 @@ def calculate_remaining_until_blocking_mode_until_value(entity: Any, remaining_k
 
 
 def get_remaining_dates(hass: HomeAssistant, name: str) -> dict[str, datetime]:
-    """..."""
+    """Retrieve the remaining dates cache from the first registered switch entity.
+
+    Args:
+        hass (HomeAssistant): The Home Assistant instance.
+        name (str): The name of the Pi-hole instance used to scope the entity list.
+
+    Returns:
+        dict[str, datetime]: A dictionary of remaining dates keyed by their identifiers, or an empty dict if unavailable.
+
+    """
 
     entities = hass.data.get(f"pi_hole_entities_switch_{name}", [])
     entity_model = None
@@ -62,7 +100,16 @@ def get_remaining_dates(hass: HomeAssistant, name: str) -> dict[str, datetime]:
 
 
 async def sensor_update_timer(hass: HomeAssistant, name: str) -> None:
-    """..."""
+    """Update the remaining blocking mode sensor state on each timer tick.
+
+    Computes the remaining seconds and updates the entity state and attributes accordingly.
+    Triggers a full refresh when the timer reaches zero.
+
+    Args:
+        hass (HomeAssistant): The Home Assistant instance.
+        name (str): The name of the Pi-hole instance used to scope the entity lookup.
+
+    """
 
     entity = find_entity_sensor(hass, "remaining_until_blocking_mode", name)
 
@@ -95,7 +142,16 @@ async def sensor_update_timer(hass: HomeAssistant, name: str) -> None:
 
 
 async def switch_update_timer(hass: HomeAssistant, name: str) -> None:
-    """..."""
+    """Update all switch entity states related to blocking timers on each timer tick.
+
+    Iterates over all remaining dates, updates attributes and remaining seconds for each
+    switch entity, and re-enables blocking when the timer expires.
+
+    Args:
+        hass (HomeAssistant): The Home Assistant instance.
+        name (str): The name of the Pi-hole instance used to scope the entity lookup.
+
+    """
 
     remaining_dates: dict[str, datetime] = get_remaining_dates(hass, name)
 

--- a/custom_components/pi_hole_v6/config_flow.py
+++ b/custom_components/pi_hole_v6/config_flow.py
@@ -46,6 +46,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_data_config_schema(user_input: Any) -> vol.Schema:
+    """Build and return the voluptuous schema for the main config flow form.
+
+    Args:
+        user_input (Any): Previously entered user input used to pre-fill default values.
+
+    Returns:
+        vol.Schema: The schema to be used in the config flow form.
+
+    """
     return vol.Schema(
         {
             vol.Required(
@@ -150,6 +159,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler()
 
     async def _async_try_connect(self) -> dict[str, str]:
+        """Attempt to connect to the Pi-hole API using the current config.
+
+        Returns:
+            dict[str, str]: An empty dict on success, or a dict mapping a field key
+            to an error string on failure.
+
+        """
         session: client.ClientSession = async_get_clientsession(self.hass, verify_ssl=False)
 
         api_client: ClientAPI = ClientAPI(
@@ -177,6 +193,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
 
 def _get_data_option_schema() -> vol.Schema:
+    """Build and return the voluptuous schema for the options flow form.
+
+    Returns:
+        vol.Schema: The schema to be used in the options flow form.
+
+    """
     return vol.Schema(
         {
             vol.Required(
@@ -205,6 +227,15 @@ def _get_data_option_schema() -> vol.Schema:
 async def _async_validate_input(
     user_input: dict[str, Any],
 ) -> Any:
+    """Validate the user input from the options flow form.
+
+    Args:
+        user_input (dict[str, Any]): The input submitted by the user in the options form.
+
+    Returns:
+        Any: An empty dict if the input is valid, or a dict mapping a field key to an error string.
+
+    """
     if user_input[CONF_UPDATE_INTERVAL] == 1:
         return {CONF_UPDATE_INTERVAL: "invalid_update_interval"}
 
@@ -215,7 +246,18 @@ class OptionsFlowHandler(OptionsFlow):
     """Options flow used to change configuration (options) of existing instance of integration."""
 
     async def async_step_init(self, user_input: Any) -> ConfigFlowResult:
-        """..."""
+        """Handle the initial step of the options flow.
+
+        Validates the user input if provided, updates the config entry and
+        returns the form pre-filled with current values otherwise.
+
+        Args:
+            user_input (Any): The input submitted by the user, or None when displaying the form.
+
+        Returns:
+            ConfigFlowResult: The result of the options flow step.
+
+        """
         if user_input is not None:  # we asked to validate values entered by user
             errors = await _async_validate_input(user_input)
 

--- a/custom_components/pi_hole_v6/exceptions.py
+++ b/custom_components/pi_hole_v6/exceptions.py
@@ -60,6 +60,7 @@ class ClientConnectorError(Exception):
 
         Args:
             custom_message (str): An optional additional message to append to the default error message.
+                If empty (default), only the default message is used.
 
         """
         new_message: str = self.message

--- a/custom_components/pi_hole_v6/exceptions.py
+++ b/custom_components/pi_hole_v6/exceptions.py
@@ -10,7 +10,7 @@ class APIError(Exception):
     message: str = ""
 
     def __init__(self) -> None:
-        """..."""
+        """Initialize the APIError exception with the class-level message."""
         super().__init__(self.message)
 
 
@@ -20,7 +20,7 @@ class ActionExecutionError(Exception):
     message: str = "The action requested has failed. Please check HA logs or Pi-hole logs."
 
     def __init__(self) -> None:
-        """..."""
+        """Initialize the ActionExecutionError exception with the class-level message."""
         super().__init__(self.message)
 
 
@@ -32,7 +32,7 @@ class AbortLogoutError(Exception):
     message: str = "Logout call is not relevant. Maybe no session is active. Please check HA logs or Pi-hole logs."
 
     def __init__(self) -> None:
-        """..."""
+        """Initialize the AbortLogoutError exception with the class-level message."""
         super().__init__(self.message)
 
 
@@ -56,7 +56,12 @@ class ClientConnectorError(Exception):
     message: str = "The Pi-hole V6 server seems to be unreachable. Please check HA logs or Pi-hole logs."
 
     def __init__(self, custom_message: str = "") -> None:
-        """..."""
+        """Initialize the ClientConnectorError exception, optionally appending a custom message.
+
+        Args:
+            custom_message (str): An optional additional message to append to the default error message.
+
+        """
         new_message: str = self.message
 
         if custom_message != "":
@@ -71,7 +76,7 @@ class ContentTypeError(Exception):
     message: str = "Invalid content type returned by the API. Please check HA logs or Pi-hole logs."
 
     def __init__(self) -> None:
-        """..."""
+        """Initialize the ContentTypeError exception with the class-level message."""
         super().__init__(self.message)
 
 

--- a/custom_components/pi_hole_v6/helper.py
+++ b/custom_components/pi_hole_v6/helper.py
@@ -1,4 +1,4 @@
-"""..."""
+"""Helper utility functions for the Pi-hole V6 integration."""
 
 from homeassistant.util import slugify
 

--- a/custom_components/pi_hole_v6/sensor.py
+++ b/custom_components/pi_hole_v6/sensor.py
@@ -167,7 +167,7 @@ async def async_setup_entry(
     hass.data[f"pi_hole_entities_sensor_{name}"].extend(sensors)
 
     async def update_timer(_: Any) -> None:
-        """..."""
+        """Trigger sensor state update on a time interval basis."""
         await sensor_update_timer(hass, name)
 
     async_track_time_interval(hass, update_timer, timedelta(seconds=1))
@@ -239,7 +239,14 @@ class PiHoleV6Sensor(PiHoleV6Entity, SensorEntity):
         return ""
 
     def native_remaining_until_blocking_mode(self) -> int:
-        """..."""
+        """Compute the remaining seconds until blocking mode is automatically restored.
+
+        Updates the cache of remaining dates based on the current blocking timer value.
+
+        Returns:
+            int: Remaining seconds until blocking mode is restored, or 0 if no timer is active.
+
+        """
 
         value = round(self.api.cache_blocking["timer"]) if self.api.cache_blocking["timer"] is not None else 0
 

--- a/custom_components/pi_hole_v6/switch.py
+++ b/custom_components/pi_hole_v6/switch.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     hass.data[f"pi_hole_entities_switch_{name}"].extend(switches)
 
     async def update_timer(_: Any) -> None:
-        """..."""
+        """Trigger switch state update on a time interval basis."""
         await switch_update_timer(hass, name)
 
     async_track_time_interval(hass, update_timer, timedelta(seconds=1))
@@ -120,7 +120,7 @@ class PiHoleV6Switch(PiHoleV6Entity, SwitchEntity):
         server_unique_id: str,
         description: SwitchEntityDescription,
     ) -> None:
-        """..."""
+        """Initialize a Pi-hole V6 switch."""
         name: str = coordinator.name
         super().__init__(api, coordinator, name, server_unique_id)
         self.entity_description = description
@@ -188,12 +188,18 @@ class PiHoleV6Switch(PiHoleV6Entity, SwitchEntity):
             _LOGGER.exception("Unable to %s Pi-hole V6", action)
 
     async def async_service_disable(self, duration: Any = None) -> None:
-        """..."""
+        """Disable the Pi-hole blocking via the service call.
+
+        Args:
+            duration (Any): Optional duration as a timedelta or int (seconds) for which
+            blocking should be disabled. If None, disables indefinitely.
+
+        """
         duration_seconds: int | None = calculate_duration(duration, self._name)
         await self.async_turn_switch(action="disable", duration=duration_seconds)
 
     async def async_service_enable(self) -> None:
-        """..."""
+        """Enable the Pi-hole blocking via the service call."""
         _LOGGER.debug("Enabling Pi-hole '%s'", self.name)
         await self.async_turn_switch(action="enable")
 
@@ -213,7 +219,7 @@ class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):
         description: SwitchEntityDescription,
         group: dict[str, Any],
     ) -> None:
-        """..."""
+        """Initialize a Pi-hole V6 group switch."""
         api: PiholeAPI = hole_data.api
         coordinator: DataUpdateCoordinator = hole_data.coordinator
 
@@ -275,13 +281,18 @@ class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):
             _LOGGER.exception("Unable to %s Pi-hole V6 group %s", action, self.group_name)
 
     async def async_service_enable(self) -> None:
-        """..."""
-
+        """Enable the Pi-hole group blocking via the service call."""
         _LOGGER.debug("Enabling Pi-hole '%s'", self.name)
         await self.async_turn_switch(action="enable")
 
     async def async_service_disable(self, duration: Any = None) -> None:
-        """..."""
+        """Disable the Pi-hole group blocking via the service call.
+
+        Args:
+            duration (Any): Optional duration as a timedelta or int (seconds) for which
+            the group should be disabled. If None, disables indefinitely.
+
+        """
         duration_seconds: int | None = calculate_duration(duration, f"group/{self.group_name}")
         await self.async_turn_switch(action="disable", duration=duration_seconds)
 
@@ -334,7 +345,16 @@ class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):
 
 
 def calculate_duration(duration: Any, name: str) -> int | None:
-    """..."""
+    """Calculate the duration in seconds from a timedelta or integer value.
+
+    Args:
+        duration (Any): The duration to convert. Can be a timedelta, an int (seconds), or None.
+        name (str): The name of the Pi-hole instance, used for logging purposes.
+
+    Returns:
+        int | None: The duration in seconds, or None if no duration was provided.
+
+    """
 
     duration_seconds: int | None = None
 

--- a/custom_components/pi_hole_v6/update.py
+++ b/custom_components/pi_hole_v6/update.py
@@ -121,7 +121,15 @@ class PiHoleV6UpdateEntity(PiHoleV6Entity, UpdateEntity):
             self._attr_title = description.title + " (only for information, please check other update entities)"
 
     def get_entity_registry_enabled_value(self) -> bool:
-        """..."""
+        """Determine whether the entity should be enabled in the registry by default.
+
+        Returns True if the entity matches the Docker context (Docker installed/not installed),
+        False otherwise.
+
+        Returns:
+            bool: True if the entity should be enabled by default, False otherwise.
+
+        """
 
         try:
             if (


### PR DESCRIPTION
## Description

This PR adds all missing docstrings across the integration and fixes inconsistencies between method signatures and their documentation.

## Changes

### Docstrings added
- `api.py` — 10 methods
- `exceptions.py` — 5 `__init__` methods
- `common.py` — 6 functions + module docstring
- `config_flow.py` — 5 methods/functions
- `__init__.py` — 2 functions
- `button.py` — `async_setup_entry`
- `update.py` — `get_entity_registry_enabled_value`
- `helper.py` — module docstring

### Docstrings fixed (coherence between signature and documentation)
- `api.py` — `__init__`: added missing `session` and `password` parameters
- `api.py` — `call_login`: removed non-existent `password` parameter (uses `self._password` internally)
- `api.py` — `call_padd`: added missing `full` parameter
- `api.py` — `call_group_disable` / `call_group_enable`: added missing `group` parameter
- `api.py` — `call_get_ftl_info_messages_count`: corrected description (count, not list)
- `api.py` — `call_blocking_disabled`: corrected `duration` parameter description
- `exceptions.py` — `ClientConnectorError.__init__`: documented default value of `custom_message`