### PR TITLE
refactor: fix remaining code quality issues

### DIFF
--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -120,11 +120,11 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
             _LOGGER.exception(log_message)
             raise
 
-        result_data: dict[str, Any] = {}
+        result_data: str | None = None
 
         if request.status < 400 and request.text != "":
             try:
-                result_data: str = await self._try_to_retrieve_json_result(request, privacy=False)
+                result_data = await self._try_to_retrieve_json_result(request, privacy=False)
                 message: str = await self._create_log_message_on_api_result(request, method, url)
 
                 if "password incorrect" not in message:

--- a/custom_components/pi_hole_v6/common.py
+++ b/custom_components/pi_hole_v6/common.py
@@ -197,5 +197,5 @@ async def switch_update_timer(hass: HomeAssistant, name: str) -> None:
                 await switch_entity.async_turn_switch(action="enable", with_update=True)
                 need_refresh = True
 
-    if need_refresh is True:
+    if need_refresh is True and switch_entity is not None:
         hass.async_create_task(switch_entity.async_update_ha_state(force_refresh=True))

--- a/custom_components/pi_hole_v6/switch.py
+++ b/custom_components/pi_hole_v6/switch.py
@@ -283,7 +283,7 @@ class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):
     async def async_service_enable(self) -> None:
         """Enable the Pi-hole group blocking via the service call."""
         _LOGGER.debug("Enabling Pi-hole '%s'", self.name)
-        await self.async_turn_switch(action="enable")
+        await self.async_turn_service(action="enable")
 
     async def async_service_disable(self, duration: Any = None) -> None:
         """Disable the Pi-hole group blocking via the service call.
@@ -294,9 +294,9 @@ class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):
 
         """
         duration_seconds: int | None = calculate_duration(duration, f"group/{self.group_name}")
-        await self.async_turn_switch(action="disable", duration=duration_seconds)
+        await self.async_turn_service(action="disable", duration=duration_seconds)
 
-    async def async_turn_switch(self, action: str, duration: Any = None, with_update: bool = True) -> None:
+    async def async_turn_service(self, action: str, duration: Any = None, with_update: bool = True) -> None:
         """Turn on/off the service."""
 
         if action == "enable":


### PR DESCRIPTION
## Description

This PR addresses the 3 remaining code quality issues identified during the review of `develop`.

## Changes

### `api.py`
- **`refactor: change result_data type`** — Corrected the type annotation of `result_data` from the incorrect `str` re-annotation to `str | None = None`, consistent with the return type of `_try_to_retrieve_json_result`.

### `common.py`
- **`Add check for switch_entity before refreshing state`** — Added a `switch_entity is not None` guard before calling `async_update_ha_state` at the end of `switch_update_timer`, preventing a potential `UnboundLocalError` if no entity was found during the loop.

### `switch.py`
- **`Rename async_turn_switch to async_turn_service`** — In `PiHoleV6Group`, renamed the internal method `async_turn_switch` to `async_turn_service` to avoid confusion with the parent class `PiHoleV6Switch.async_turn_switch`. The service methods `async_service_enable` and `async_service_disable` now call `async_turn_service` directly, making the class hierarchy clearer and more consistent.
