### PR TITLE
fix: remove ruff comments

### DIFF
--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -40,7 +40,6 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
           url (str): Represents the URL of API endpoint. Defaults to "http://pi.hole".
           password (str): The password used to authenticate against the Pi-hole API. Defaults to "".
 
-
         """
         self._call_lock = asyncio.Lock()
         self._password: str = password

--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attributes
     """Pi-hole API Client."""
 
-    def __init__(  # noqa: D417
+    def __init__(
         self,
         session: client.ClientSession,
         url: str = "http://pi.hole",


### PR DESCRIPTION
## Summary

Remove ruff inline comments (`# noqa`, `# pylint disable`, etc.) that are no longer necessary after linter configuration improvements.

## Commits

- `fix: remove ruff comment`
- `fix: remove blank line`
