### PR TITLE
fix: improve and fix docstrings across all modules

### DIFF
--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -1,4 +1,4 @@
-"""The above class represents Pi-hole API Client with methods for authentication, retrieving summary data, managing blocking status, and logging requests."""
+"""Pi-hole V6 API client for authentication, data retrieval, and blocking management."""
 
 import asyncio
 import json
@@ -159,6 +159,9 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
 
         Returns:
             dict[str, Any] | None: The parsed JSON content, or None if the response has no body.
+
+        Raises:
+            json.JSONDecodeError: If the response body cannot be parsed as valid JSON after decoding.
 
         """
 
@@ -893,6 +896,9 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
 
     async def call_action_ftl_purge_diagnosis_messages(self) -> dict[str, Any]:
         """Purge all FTL diagnosis messages.
+
+        Iterates over cached messages and deletes each one via the API.
+        Clears the local message cache after deletion.
 
         Returns:
             dict[str, Any]: A dictionary with the keys "code", "reason", and "data".

--- a/custom_components/pi_hole_v6/binary_sensor.py
+++ b/custom_components/pi_hole_v6/binary_sensor.py
@@ -30,7 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True, kw_only=True)
 class PiHoleV6BinarySensorEntityDescription(BinarySensorEntityDescription):
-    """Describes PiHole binary sensor entity."""
+    """Describes PiHole binary sensor entity.
+
+    Attributes:
+        state_value (Callable[[PiholeAPI], Any]): A callable that takes the API client
+            and returns the current state value of the sensor.
+
+    """
 
     state_value: Callable[[PiholeAPI], Any]
 

--- a/custom_components/pi_hole_v6/button.py
+++ b/custom_components/pi_hole_v6/button.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True, kw_only=True)
 class PiholeV6ButtonEntityDescription(ButtonEntityDescription):
-    """Class describing Pi-hole V6 button entities."""
+    """Description of a Pi-hole V6 button entity used to trigger actions on the Pi-hole instance."""
 
 
 BUTTON_TYPES: tuple[PiholeV6ButtonEntityDescription, ...] = (
@@ -130,6 +130,10 @@ class PiHoleV6Button(PiHoleV6Entity, ButtonEntity):
 
         Returns:
             None
+
+        Raises:
+            ClientConnectorError: If the server is unreachable during the action execution.
+            APIError: If the API returns an error status code during the action execution.
 
         """
 

--- a/custom_components/pi_hole_v6/common.py
+++ b/custom_components/pi_hole_v6/common.py
@@ -109,6 +109,9 @@ async def sensor_update_timer(hass: HomeAssistant, name: str) -> None:
         hass (HomeAssistant): The Home Assistant instance.
         name (str): The name of the Pi-hole instance used to scope the entity lookup.
 
+    Returns:
+        None
+
     """
 
     entity = find_entity_sensor(hass, "remaining_until_blocking_mode", name)
@@ -152,6 +155,9 @@ async def switch_update_timer(hass: HomeAssistant, name: str) -> None:
     Args:
         hass (HomeAssistant): The Home Assistant instance.
         name (str): The name of the Pi-hole instance used to scope the entity lookup.
+
+    Returns:
+        None
 
     """
 

--- a/custom_components/pi_hole_v6/config_flow.py
+++ b/custom_components/pi_hole_v6/config_flow.py
@@ -202,6 +202,9 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             dict[str, str]: An empty dict on success, or a dict mapping a field key
             to an error string on failure.
 
+        Raises:
+            APIError: If the API returns an unexpected error status code.
+
         """
         session: client.ClientSession = async_get_clientsession(self.hass, verify_ssl=False)
 

--- a/custom_components/pi_hole_v6/exceptions.py
+++ b/custom_components/pi_hole_v6/exceptions.py
@@ -1,4 +1,4 @@
-"""The above classes represent the specific exceptions raised during the Pi-hole API calls."""
+"""Custom exceptions raised during Pi-hole V6 API calls."""
 
 from abc import abstractmethod
 from typing import Any

--- a/custom_components/pi_hole_v6/update.py
+++ b/custom_components/pi_hole_v6/update.py
@@ -24,7 +24,15 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class PiHoleV6UpdateEntityDescription(UpdateEntityDescription):
-    """Describes PiHoleV6 update entity."""
+    """Describes PiHoleV6 update entity.
+
+    Attributes:
+        installed_version (Callable[[dict[str, Any]], str] | None): A callable that takes the versions dict and returns the currently installed version string.
+        latest_version (Callable[[dict[str, Any]], str] | None): A callable that takes the versions dict and returns the latest available version string.
+        release_base_url (str | None): The base URL used to build the release notes URL.
+        title (str | None): The display title of the update entity.
+
+    """
 
     installed_version: Callable[[dict[str, Any]], str] | None = None
     latest_version: Callable[[dict[str, Any]], str] | None = None
@@ -89,6 +97,7 @@ async def async_setup_entry(
         None
 
     """
+
     hole_data = entry.runtime_data
 
     async_add_entities(
@@ -174,12 +183,13 @@ class PiHoleV6UpdateEntity(PiHoleV6Entity, UpdateEntity):
 
     @property
     def installed_version(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
-        """Version installed and in use.
+        """Return the currently installed version by delegating to the entity description callable.
 
         Returns:
-            str | None: The installed version string, or None if unavailable.
+            str | None: The installed version string extracted from the padd cache, or None if unavailable.
 
         """
+
         versions: dict[str, Any] | None = self.api.cache_padd["version"]
         if isinstance(versions, dict) and self.entity_description.installed_version is not None:
             return self.entity_description.installed_version(versions)
@@ -187,12 +197,13 @@ class PiHoleV6UpdateEntity(PiHoleV6Entity, UpdateEntity):
 
     @property
     def latest_version(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
-        """Latest version available for install.
+        """Return the latest available version by delegating to the entity description callable.
 
         Returns:
-            str | None: The latest available version string, or None if unavailable.
+            str | None: The latest version string extracted from the padd cache, or None if unavailable.
 
         """
+
         versions: dict[str, Any] | None = self.api.cache_padd["version"]
         if isinstance(versions, dict) and self.entity_description.latest_version is not None:
             return self.entity_description.latest_version(versions)
@@ -200,10 +211,12 @@ class PiHoleV6UpdateEntity(PiHoleV6Entity, UpdateEntity):
 
     @property
     def release_url(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
-        """URL to the full release notes of the latest version available.
+        """Return the release notes URL built from the base URL and the latest version.
 
         Returns:
-            str | None: The release URL, or None if no latest version is available.
+            str | None: The full release URL combining release_base_url and latest_version,
+                or None if no latest version is available.
 
         """
+
         return f"{self.entity_description.release_base_url}/{self.latest_version}"


### PR DESCRIPTION
## Summary

This PR fixes and improves docstrings across all Python modules of the integration.

## Changes

- `api.py` : fixed module docstring, added `Raises` section to `_try_to_retrieve_json_result`, improved docstring for `call_action_ftl_purge_diagnosis_messages`
- `binary_sensor.py` : added `Attributes` section to `PiHoleV6BinarySensorEntityDescription`
- `button.py` : improved docstring of `PiholeV6ButtonEntityDescription`, added `Raises` section to `async_press`
- `common.py` : added missing `Returns: None` to `sensor_update_timer` and `switch_update_timer`
- `config_flow.py` : added missing `Raises` section to `_async_try_connect`
- `exceptions.py` : fixed module docstring
- `update.py` : added `Attributes` section to `PiHoleV6UpdateEntityDescription`, improved descriptions for `installed_version`, `latest_version` and `release_url`
