### PR TITLE
Release v1.19

### DIFF
--- a/custom_components/pi_hole_v6/device_tracker.py
+++ b/custom_components/pi_hole_v6/device_tracker.py
@@ -6,8 +6,10 @@ import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.components.device_tracker.entity import ScannerEntity
+from homeassistant.components.device_tracker import (
+    ScannerEntity,  # pyright: ignore[reportPrivateImportUsage]
+    SourceType,  # pyright: ignore[reportPrivateImportUsage]
+)
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator


### PR DESCRIPTION
## What's Changed

The **device tracking feature** introduced in the previous release relied on import paths only available starting with version `2026.6.0`.

### Fixed
 
- Fixed an import error in `device_tracker` that broke the integration on Home Assistant not updated.

Sorry for the inconvenience.