### PR TITLE
fix: update star history chart to working endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,4 +200,4 @@ Enjoy!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bastgau/ha-pi-hole-v6&type=Date)](https://www.star-history.com/#bastgau/ha-pi-hole-v6&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bastgau/ha-pi-hole-v6&type=Date)](https://star-history.dera.page/#bastgau/ha-pi-hole-v6&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken due to the previous service hitting GitHub stargazer API restrictions. This fix points it to the new working endpoint so the chart renders correctly. A fix is necessary to keep the chart useful.