### PR TITLE
Raise UpdateFailed on transient fetch errors instead of letting them escape the coordinator

### DIFF
--- a/custom_components/pi_hole_v6/__init__.py
+++ b/custom_components/pi_hole_v6/__init__.py
@@ -188,6 +188,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: PiHoleV6ConfigEntry) -> 
         Raises:
             ConfigEntryAuthFailed: If the credentials are invalid or expired.
             DataStructureError: If the API returns an unexpected data structure.
+            UpdateFailed: If the Pi-hole is unreachable or the API returns an error,
+            so the coordinator marks the entities unavailable and retries.
 
         """
 

--- a/custom_components/pi_hole_v6/__init__.py
+++ b/custom_components/pi_hole_v6/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import Api as PiholeAPI
 from .const import (
@@ -28,7 +28,7 @@ from .const import (
     DOMAIN,
     MIN_TIME_BETWEEN_UPDATES,
 )
-from .exceptions import APIError, DataStructureError, UnauthorizedError
+from .exceptions import APIError, ClientConnectorError, DataStructureError, UnauthorizedError
 
 if TYPE_CHECKING:
     from aiohttp import client
@@ -207,6 +207,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PiHoleV6ConfigEntry) -> 
         except UnauthorizedError as err:
             msg: str = "Credentials must be updated."
             raise ConfigEntryAuthFailed(msg) from err
+
+        except (ClientConnectorError, APIError) as err:
+            raise UpdateFailed(str(err)) from err
 
         try:
             result = await api_client.call_get_ftl_info_messages()


### PR DESCRIPTION
### Problem

`async_update_data()` in `__init__.py` catches only `UnauthorizedError` around the `async_get_all_data()` call:

```python
try:
    await async_get_all_data(api_client=api_client, enable_device_tracker=enable_device_tracker)
except UnauthorizedError as err:
    msg: str = "Credentials must be updated."
    raise ConfigEntryAuthFailed(msg) from err
```

Everything else propagates out of the update method. In particular `ClientConnectorError` is defined in `exceptions.py` as a plain `Exception` subclass rather than an `APIError`, so it is not covered by any handler here.

### Effect

When the update method raises an exception that isn't `UpdateFailed`, `ConfigEntryAuthFailed`, or `ConfigEntryError`, `DataUpdateCoordinator` falls into its generic handler:

```python
except Exception as err:
    self.last_exception = err
    self.last_update_success = False
    self.logger.exception("Unexpected error fetching %s data", self.name)
```

`logger.exception()` emits the full traceback. Because the Pi-hole errors are chained (`OSError` → `aiohttp.ClientConnectorError` → `pi_hole_v6.exceptions.ClientConnectorError`), each failed poll produces a long multi-frame block with two `The above exception was the direct cause of...` sections.

If the Pi-hole host is unreachable for a while, this repeats at every update interval. A short outage of roughly fifteen minutes produced a few thousand log lines from this integration alone, which made the actual cause hard to find.

Raising `UpdateFailed` instead takes the intended branch:

```python
except UpdateFailed as err:
    self.logger.error("Error fetching %s data: %s", self.name, err)
```

one concise line, entities correctly marked unavailable, and normal retry backoff.

### Fix

Catch `ClientConnectorError` and `APIError` and re-raise as `UpdateFailed`. `UnauthorizedError` is a subclass of `APIError` but is matched by the earlier handler, so reauth still raises `ConfigEntryAuthFailed` as before.

The custom exception messages are preserved via `str(err)`, so the coordinator's single line still says exactly what went wrong, for example `Error fetching PiHole data: The Pi-hole V6 server seems to be unreachable. ...`.

### Notes

- Observed on v1.19.0; `develop` looks unchanged in this area.
- I deliberately kept the scope to the two exception groups I actually saw (`ClientConnectorError` from an unreachable host, `BadRequestError` from a host that was still starting up). `ContentTypeError` and `AbortLogoutError` are also plain `Exception` subclasses and would take the same traceback path, so they may be worth folding in — happy to extend this if you'd prefer.
- I have the before logs showing the traceback chain. The patched version is deployed and running, but I have not yet caught the failure branch executing post-fix, since it needs the Pi-hole host to actually go away. So this is verified by inspection against the coordinator source rather than by observing the improved output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
