### PR TITLE
fix: restore blocking when the global countdown expires

### DIFF
--- a/custom_components/pi_hole_v6/switch.py
+++ b/custom_components/pi_hole_v6/switch.py
@@ -280,6 +280,26 @@ class PiHoleV6Switch(PiHoleV6Entity, SwitchEntity):  # pyright: ignore[reportInc
         _LOGGER.debug("Enabling Pi-hole '%s'", self.name)
         await self.async_turn_switch(action="enable")
 
+    async def async_turn_service(self, action: str, duration: Any = None, with_update: bool = True) -> None:
+        """Turn on/off the Pi-hole blocking, exposing the same entry point as a group switch.
+
+        The blocking timer iterates over every switch holding a remaining date, whether it is this
+        global switch or a group one, and calls this method when the countdown reaches zero. Both
+        classes therefore have to answer to the same name.
+
+        Args:
+            action (str): The action to perform, either "enable" or "disable".
+            duration (Any): Optional duration in seconds for which blocking should be disabled.
+                Only relevant when action is "disable". Defaults to None.
+            with_update (bool): If True, triggers a state update after the action. Defaults to True.
+
+        Returns:
+            None
+
+        """
+
+        await self.async_turn_switch(action=action, duration=duration, with_update=with_update)
+
 
 class PiHoleV6Group(PiHoleV6Entity, SwitchEntity):  # pyright: ignore[reportIncompatibleVariableOverride]
     """Representation of a Pi-hole V6 group.


### PR DESCRIPTION
Disabling blocking for a set duration and letting the countdown run out raised an AttributeError:

    'PiHoleV6Switch' object has no attribute 'async_turn_service'

The blocking timer walks every switch holding a remaining date and calls async_turn_service when a countdown reaches zero. Group switches define that method, the global switch only defined async_turn_switch, so the global countdown crashed the timer job.

PiHoleV6Switch now exposes async_turn_service too, delegating to async_turn_switch, so both classes answer the same call. As a side effect the stale global entry in the remaining dates cache is dropped right away, since async_turn_switch already clears it on enable.

Blocking itself was never left off: the duration is handed to Pi-hole, which restores blocking on its own. What the crash prevented was Home Assistant refreshing the switch immediately, which had to wait for the next scheduled update.