### PR TITLE
fix: refresh the message count after purging FTL diagnosis messages

### DIFF
--- a/custom_components/pi_hole_v6/api.py
+++ b/custom_components/pi_hole_v6/api.py
@@ -972,7 +972,10 @@ class Api:  # pylint: disable=too-many-public-methods, too-many-instance-attribu
                 method="DELETE",
             )
 
+        # Every known message was just deleted, so the cached count would otherwise stay stale until
+        # the next refresh. Pi-hole may have raised a new one meanwhile, which that refresh will correct.
         self.cache_ftl_info["message_list"] = []
+        self.cache_ftl_info["message_count"] = 0
 
         return {
             "code": result["code"],

--- a/custom_components/pi_hole_v6/button.py
+++ b/custom_components/pi_hole_v6/button.py
@@ -156,6 +156,7 @@ class PiHoleV6Button(PiHoleV6Entity, ButtonEntity):  # pyright: ignore[reportInc
                     self.schedule_update_ha_state(force_refresh=True)
                 case "action_ftl_purge_diagnosis_messages":
                     await self.api.call_action_ftl_purge_diagnosis_messages()
+                    await self._coordinator_stats.async_request_refresh()
                     self.schedule_update_ha_state(force_refresh=True)
                 case _:
                     pass


### PR DESCRIPTION
Pressing the purge button left sensor.<service>_ftl_info_message_count on its previous value until the next scheduled refresh, up to five minutes later.

Two causes. The purge emptied cache_ftl_info["message_list"] but left ["message_count"] untouched, which is the key the sensor actually reads, so notifying the listeners re-rendered the very same stale value. And nothing asked the stats coordinator, which owns that sensor, to fetch again.

The cached count is now zeroed along with the list, so the sensor drops to zero immediately, and the button requests a stats refresh, which reconciles with Pi-hole in case a new message was raised between the last fetch and the purge. Same optimistic pattern the group switches already use on their enabled flag.